### PR TITLE
Fixed adding new TXT record for Azure

### DIFF
--- a/src/DnsClientProject/Providers/Azure/Azure.cs
+++ b/src/DnsClientProject/Providers/Azure/Azure.cs
@@ -258,7 +258,7 @@ namespace DnsClientProject.Providers
                     case RecordType.TXT:
                         if (!record.TxtRecords.SelectMany(x => x.Value).Any(x => x == opts.Value))
                         {
-                            record.TxtRecords.First().Value.Add(opts.Value);
+                            record.TxtRecords.Add(new TxtRecord { Value = new List<string> { opts.Value } });
                             dirty = true;
                         }
                         break;


### PR DESCRIPTION
Fixed adding new TXT record for Azure. Now instead adding a single value to the record it adds a new record with the same name
Issue #2 